### PR TITLE
Add support for GZIP flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ bFLT files are commonly found in uclinux images, and are greatly documented here
 
  * Parses and loads sections according to the file header
  * Extracts GZip data section if GZDATA flag is set
+ * Extracts GZip text and data sections if GZIP flag is set
  * Patches GOT entries if GOTPIC flag is set, and sets pointers for further analysis
  * Patches relocations
 

--- a/src/main/help/help/topics/bflt_loader/help.html
+++ b/src/main/help/help/topics/bflt_loader/help.html
@@ -10,7 +10,7 @@
     <META name="ProgId" content="FrontPage.Editor.Document">
 
     <TITLE>Skeleton Help File for a Module</TITLE>
-    <LINK rel="stylesheet" type="text/css" href="../../shared/Frontpage.css">
+    <LINK rel="stylesheet" type="text/css" href="help/shared/DefaultStyle.css">
   </HEAD>
 
   <BODY>


### PR DESCRIPTION
- Added support for GZIP flag (both .text and .data sections GZIP compressed) to loader
- Refactored code to simplify and avoid some duplication
- Modified relocation patching code to deal with GZIP sections
- Fixed problem with setPointerIndex call by changing constant to "0L" (caused exception when used in Ghidra 11.1.1 for some reason)
- Copied help.html file from Ghidra 11.1.1 skeleton (stylesheet changed from Frontpage.css to DefaultStyle.css)